### PR TITLE
fix return in finally

### DIFF
--- a/raspyrfm_client/client.py
+++ b/raspyrfm_client/client.py
@@ -242,9 +242,10 @@ class RaspyRFMClient:
                             found_gateways.append(gateway.create_from_broadcast(address[0], message))
 
             except socket.timeout:
-                return found_gateways
-            finally:
-                return found_gateways
+                # ignore timeout errors
+                pass
+
+            return found_gateways
 
     def send(self, gateway: Gateway, device: ControlUnit, action: Action) -> None:
         """


### PR DESCRIPTION
Using `return` in a finally clauses is a SyntaxWarning in Python 3.14.
https://peps.python.org/pep-0765/